### PR TITLE
Modify: replace useStore hook with adapter

### DIFF
--- a/src/ui/Cookie/Cookie.tsx
+++ b/src/ui/Cookie/Cookie.tsx
@@ -2,7 +2,7 @@ import { contains } from "../../domain/cart";
 import { Product } from "../../domain/product";
 import { useAddToCart } from "../../application/addToCart";
 
-import { useStore } from "../../services/store";
+import { useUserStorage, useCartStorage } from "../../services/storageAdapter";
 import styles from "./Cookie.module.css";
 import { Toppings } from "./Toppings";
 
@@ -11,7 +11,8 @@ type CookieProps = {
 };
 
 export function Cookie({ cookie }: CookieProps) {
-  const { user, cart } = useStore();
+  const { user } = useUserStorage();
+  const { cart } = useCartStorage();
   const { addToCart } = useAddToCart();
 
   return (
@@ -26,7 +27,9 @@ export function Cookie({ cookie }: CookieProps) {
         </button>
       )}
 
-      {contains(cart, cookie) && <span className={styles.contains}>In your cart</span>}
+      {contains(cart, cookie) && (
+        <span className={styles.contains}>In your cart</span>
+      )}
     </article>
   );
 }


### PR DESCRIPTION
In the cookie UI, we found that the store was accessed directly using the useStore rather than through the adapter.

I thought it was right to approach using each adapter rather than directly from an architectural point of view, so I modified it in the direction of approaching using an adapter.

I was very impressed by the article and repertoire, and I sincerely thank you for your help.